### PR TITLE
Add function GetPlatformAccessToken

### DIFF
--- a/AltinnTestTools.sln
+++ b/AltinnTestTools.sln
@@ -1,17 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29920.165
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34202.233
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TokenGenerator", "TokenGenerator\TokenGenerator.csproj", "{51860523-231F-4BCC-97E4-BF41978237ED}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BD0CAC07-E747-4A89-A123-C2982D0D48AC}"
 	ProjectSection(SolutionItems) = preProject
-		.github\workflows\cd-tokengenerator.yml = .github\workflows\cd-tokengenerator.yml
+		LICENSE = LICENSE
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TokenGeneratorCli", "TokenGeneratorCli\TokenGeneratorCli.csproj", "{6BABB466-D89B-476E-B18A-27C59819F6DE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TokenGeneratorCli", "TokenGeneratorCli\TokenGeneratorCli.csproj", "{6BABB466-D89B-476E-B18A-27C59819F6DE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/TokenGenerator/GetPlatformAccessToken.cs
+++ b/TokenGenerator/GetPlatformAccessToken.cs
@@ -1,0 +1,54 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using TokenGenerator.Services.Interfaces;
+
+namespace TokenGenerator
+{
+    public class GetPlatformAccessToken
+    {
+        private readonly IToken tokenHelper;
+        private readonly IRequestValidator requestValidator;
+        private readonly IAuthorization authorization;
+        private readonly Settings settings;
+
+        public GetPlatformAccessToken(IToken tokenHelper, IRequestValidator requestValidator, IAuthorization authorization, IOptions<Settings> settings)
+        {
+            this.tokenHelper = tokenHelper;
+            this.requestValidator = requestValidator;
+            this.authorization = authorization;
+            this.settings = settings.Value;
+        }
+
+        [FunctionName(nameof(GetPlatformAccessToken))]
+        public async Task<ActionResult> Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)] HttpRequest req)
+        {
+            ActionResult failedAuthorizationResult = await authorization.Authorize(settings.AuthorizedScopePlatform);
+            if (failedAuthorizationResult != null)
+            {
+                return failedAuthorizationResult;
+            }
+
+            requestValidator.ValidateQueryParam("env", true, tokenHelper.IsValidEnvironment, out string env);
+            requestValidator.ValidateQueryParam("app", true, tokenHelper.IsValidDottedIdentifier, out string appClaim);
+            requestValidator.ValidateQueryParam<uint>("ttl", false, uint.TryParse, out uint ttl, 1800);
+
+            if (requestValidator.GetErrors().Count > 0)
+            {
+                 return new BadRequestObjectResult(requestValidator.GetErrors());
+            }
+
+            string token = await tokenHelper.GetPlatformAccessToken(env, appClaim, ttl);
+
+            if (!string.IsNullOrEmpty(req.Query["dump"]))
+            {
+                return new OkObjectResult(tokenHelper.Dump(token));
+            }
+
+            return new OkObjectResult(token);
+        }
+    }
+}

--- a/TokenGenerator/Services/CertificatePfx.cs
+++ b/TokenGenerator/Services/CertificatePfx.cs
@@ -52,5 +52,10 @@ namespace TokenGenerator.Services
 
             return await Task.FromResult(consentTokenSigningCertificate);
         }
+
+        public Task<X509Certificate2> GetPlatformAccessTokenSigningCertificate(string environment)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/TokenGenerator/Services/Interfaces/ICertificateService.cs
+++ b/TokenGenerator/Services/Interfaces/ICertificateService.cs
@@ -7,5 +7,6 @@ namespace TokenGenerator.Services.Interfaces
     {
         Task<X509Certificate2> GetApiTokenSigningCertificate(string environment);
         Task<X509Certificate2> GetConsentTokenSigningCertificate(string environment);
+        Task<X509Certificate2> GetPlatformAccessTokenSigningCertificate(string environment);
     }
 }

--- a/TokenGenerator/Services/Interfaces/IToken.cs
+++ b/TokenGenerator/Services/Interfaces/IToken.cs
@@ -11,6 +11,8 @@ namespace TokenGenerator.Services.Interfaces
         Task<string> GetPersonalToken(string env, string[] scopes, uint userId, uint partyId, string pid, string authLvl, string consumerOrgNo, string userName, string clientAmr, uint ttl, string delegationSource);
         Task<string> GetConsentToken(string env, string[] serviceCodes, IQueryCollection queryParameters, Guid authorizationCode, string offeredBy, string coveredBy, string handledBy, uint ttl);
         Task<string> GetPlatformToken(string env, string appClaim, uint ttl);
+        Task<string> GetPlatformAccessToken(string env, string appClaim, uint ttl);
+
         string Dump(string token);
         bool IsValidAuthLvl(string authLvl);
         bool IsValidIdentifier(string identifier);

--- a/TokenGenerator/Settings.cs
+++ b/TokenGenerator/Settings.cs
@@ -8,6 +8,8 @@ namespace TokenGenerator
     {
         public string ApiTokenSigningCertNames { get; set; }
         public Dictionary<string, string> ApiTokenSigningCertNamesDict => GetKeyValuePairs(ApiTokenSigningCertNames);
+        public string PlatformAccessTokenSigningCertNames { get; set; }
+        public Dictionary<string, string> PlatformAccessTokenSigningCertNamesDict => GetKeyValuePairs(PlatformAccessTokenSigningCertNames);
         public string ConsentTokenSigningCertNames { get; set; }
         public Dictionary<string, string> ConsentTokenSigningCertNamesDict => GetKeyValuePairs(ConsentTokenSigningCertNames);
         public string BasicAuthorizationUsers { get; set; }

--- a/TokenGenerator/local.settings.json.COPYME
+++ b/TokenGenerator/local.settings.json.COPYME
@@ -6,6 +6,7 @@
   },
   "Settings": {
     "ApiTokenSigningCertNames": "dev:altinn-testtools-api-token-signing-cert",
+    "PlatformAccessTokenSigningCertNames": "dev:altinn-testtools-api-token-signing-cert",
     "AuthorizedScope": "altinn:testtools/tokengenerator",
     "AuthorizedScopeEnterprise": "altinn:testtools/tokengenerator/enterprise",
     "AuthorizedScopeEnterpriseUser": "altinn:testtools/tokengenerator/enterpriseuser",


### PR DESCRIPTION
## Description
Adding a function that can generate a Platform access token. The chain is identical to the existing Platform token, but this new function is using a separate certificate to sign the token.

We want to use this feature for testing of platform components that requires AccessToken.

## Related Issue(s)
- https://github.com/Altinn/altinn-notifications/issues/8

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
