### PR TITLE
Add systemuser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,14 @@ The application requires authentication. See https://altinn.github.io/docs/api/r
 #### Enterprise tokens (aka Maskinporten):
 `https://altinn-testtools-token-generator.azurewebsites.net/api/GetEnterpriseToken?env={environment}&scopes={scopes}&org={orgName}&orgNo={orgNo}`
 
-#### Enterprise user tokens (aka Maskinporten + Enterprise user authentication):
-`https://altinn-testtools-token-generator.azurewebsites.net/api/GetEnterpriseUserToken?env={environment}&orgNo={orgNo}&partyId={partyId}&userId={userId}&userName={userName}`
-
 #### Person tokens (aka ID-porten)
 `https://altinn-testtools-token-generator.azurewebsites.net/api/GetPersonalToken?env={environment}&scopes={scopes}&userId={userId}&partyId={partyId}&pid={pid}`
+
+#### Systemuser tokens ([see docs](https://docs.digdir.no/docs/Maskinporten/maskinporten_func_systembruker))
+`https://altinn-testtools-token-generator.azurewebsites.net/api/GetSystemUserToken?env={environment}&scopes={scopes}&systemUserId={systemUserId}&systemUserOrg={systemUserOrg}`
+
+#### Legacy (Altinn 2) Enterprise user tokens (aka Maskinporten + Enterprise user authentication):
+`https://altinn-testtools-token-generator.azurewebsites.net/api/GetEnterpriseUserToken?env={environment}&orgNo={orgNo}&partyId={partyId}&userId={userId}&userName={userName}`
 
 #### Optional parameters:
 

--- a/TokenGenerator/GetSystemUserToken.cs
+++ b/TokenGenerator/GetSystemUserToken.cs
@@ -1,0 +1,56 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Extensions.Options;
+using System.Threading.Tasks;
+using TokenGenerator.Services.Interfaces;
+
+namespace TokenGenerator
+{
+    public class GetSystemUserToken
+    {
+        private readonly Settings settings;
+        private readonly IToken tokenHelper;
+        private readonly IRequestValidator requestValidator;
+        private readonly IAuthorization authorization;
+
+        public GetSystemUserToken(IOptions<Settings> settings, IToken tokenHelper, IRequestValidator requestValidator, IAuthorization authorization)
+        {
+            this.settings = settings.Value;
+            this.tokenHelper = tokenHelper;
+            this.requestValidator = requestValidator;
+            this.authorization = authorization;
+        }
+
+        [FunctionName(nameof(GetSystemUserToken))]
+        public async Task<ActionResult> Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)] HttpRequest req)
+        {
+            ActionResult failedAuthorizationResult = await authorization.Authorize(settings.AuthorizedScopeEnterpriseUser);
+            if (failedAuthorizationResult != null)
+            {
+                return failedAuthorizationResult;
+            }
+
+            requestValidator.ValidateQueryParam("env", true, tokenHelper.IsValidEnvironment, out string env);
+            requestValidator.ValidateQueryParam("scopes", false, tokenHelper.TryParseScopes, out string[] scopes, new string[] { "altinn:enduser" });
+            requestValidator.ValidateQueryParam("systemUserOrg", false, tokenHelper.IsValidOrgNo, out string systemUserOrg, "991825827");
+            requestValidator.ValidateQueryParam("systemUserId", true, tokenHelper.IsValidIdentifier, out string systemUserId);
+            requestValidator.ValidateQueryParam<uint>("ttl", false, uint.TryParse, out uint ttl, 1800);
+
+            if (requestValidator.GetErrors().Count > 0)
+            {
+                 return new BadRequestObjectResult(requestValidator.GetErrors());
+            }
+
+            string token = await tokenHelper.GetSystemUserToken(env, scopes, systemUserOrg, systemUserId, ttl);
+
+            if (!string.IsNullOrEmpty(req.Query["dump"]))
+            {
+                return new OkObjectResult(tokenHelper.Dump(token));
+            }
+
+            return new OkObjectResult(token);
+        }
+    }
+}

--- a/TokenGenerator/GetSystemUserToken.cs
+++ b/TokenGenerator/GetSystemUserToken.cs
@@ -34,6 +34,8 @@ namespace TokenGenerator
 
             requestValidator.ValidateQueryParam("env", true, tokenHelper.IsValidEnvironment, out string env);
             requestValidator.ValidateQueryParam("scopes", false, tokenHelper.TryParseScopes, out string[] scopes, new string[] { "altinn:enduser" });
+            requestValidator.ValidateQueryParam("orgNo", false, tokenHelper.IsValidOrgNo, out string orgNo, "991825827");
+            requestValidator.ValidateQueryParam("supplierOrgNo", false, tokenHelper.IsValidOrgNo, out string supplierOrgNo);
             requestValidator.ValidateQueryParam("systemUserOrg", false, tokenHelper.IsValidOrgNo, out string systemUserOrg, "991825827");
             requestValidator.ValidateQueryParam("systemUserId", true, tokenHelper.IsValidIdentifier, out string systemUserId);
             requestValidator.ValidateQueryParam<uint>("ttl", false, uint.TryParse, out uint ttl, 1800);
@@ -43,7 +45,7 @@ namespace TokenGenerator
                  return new BadRequestObjectResult(requestValidator.GetErrors());
             }
 
-            string token = await tokenHelper.GetSystemUserToken(env, scopes, systemUserOrg, systemUserId, ttl);
+            string token = await tokenHelper.GetSystemUserToken(env, scopes, orgNo, supplierOrgNo, systemUserOrg, systemUserId, ttl);
 
             if (!string.IsNullOrEmpty(req.Query["dump"]))
             {

--- a/TokenGenerator/Services/Interfaces/IToken.cs
+++ b/TokenGenerator/Services/Interfaces/IToken.cs
@@ -8,6 +8,7 @@ namespace TokenGenerator.Services.Interfaces
     {
         Task<string> GetEnterpriseToken(string env, string[] scopes, string org, string orgNo, string supplierOrgNo, uint ttl, string delegationSource);
         Task<string> GetEnterpriseUserToken(string env, string[] scopes, string org, string orgNo, string supplierOrgNo, uint partyId, uint userId, string userName, uint ttl, string delegationSource);
+        Task<string> GetSystemUserToken(string env, string[] scopes, string systemUserOrg, string systemUserId, uint ttl);
         Task<string> GetPersonalToken(string env, string[] scopes, uint userId, uint partyId, string pid, string authLvl, string consumerOrgNo, string userName, string clientAmr, uint ttl, string delegationSource);
         Task<string> GetConsentToken(string env, string[] serviceCodes, IQueryCollection queryParameters, Guid authorizationCode, string offeredBy, string coveredBy, string handledBy, uint ttl);
         Task<string> GetPlatformToken(string env, string appClaim, uint ttl);

--- a/TokenGenerator/Services/Interfaces/IToken.cs
+++ b/TokenGenerator/Services/Interfaces/IToken.cs
@@ -8,7 +8,7 @@ namespace TokenGenerator.Services.Interfaces
     {
         Task<string> GetEnterpriseToken(string env, string[] scopes, string org, string orgNo, string supplierOrgNo, uint ttl, string delegationSource);
         Task<string> GetEnterpriseUserToken(string env, string[] scopes, string org, string orgNo, string supplierOrgNo, uint partyId, uint userId, string userName, uint ttl, string delegationSource);
-        Task<string> GetSystemUserToken(string env, string[] scopes, string systemUserOrg, string systemUserId, uint ttl);
+        Task<string> GetSystemUserToken(string env, string[] scopes, string orgNo, string supplierOrgNo, string systemUserOrg, string systemUserId, uint ttl);
         Task<string> GetPersonalToken(string env, string[] scopes, uint userId, uint partyId, string pid, string authLvl, string consumerOrgNo, string userName, string clientAmr, uint ttl, string delegationSource);
         Task<string> GetConsentToken(string env, string[] serviceCodes, IQueryCollection queryParameters, Guid authorizationCode, string offeredBy, string coveredBy, string handledBy, uint ttl);
         Task<string> GetPlatformToken(string env, string appClaim, uint ttl);

--- a/TokenGenerator/Services/SelfSignedCertificate.cs
+++ b/TokenGenerator/Services/SelfSignedCertificate.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using TokenGenerator.Services.Interfaces;
+
+namespace TokenGenerator.Services;
+
+public class SelfSignedCertificate : ICertificateService
+{
+    private readonly Lazy<Task<X509Certificate2>> _lazyCertificate;
+
+    public SelfSignedCertificate()
+    {
+        _lazyCertificate = new Lazy<Task<X509Certificate2>>(GenerateCertificate);
+    }
+
+    public Task<X509Certificate2> GetApiTokenSigningCertificate(string environment)
+    {
+        return _lazyCertificate.Value;
+    }
+
+    public Task<X509Certificate2> GetConsentTokenSigningCertificate(string environment)
+    {
+        return _lazyCertificate.Value;
+    }
+
+    public Task<X509Certificate2> GetPlatformAccessTokenSigningCertificate(string environment)
+    {
+        return _lazyCertificate.Value;
+    }
+
+    private async Task<X509Certificate2> GenerateCertificate()
+    {
+        using (RSA rsa = RSA.Create(2048))
+        {
+            var request = new CertificateRequest(
+                "cn=LocalTestCertificate",
+                rsa,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1);
+
+            var certificate = request.CreateSelfSigned(
+                DateTimeOffset.Now,
+                DateTimeOffset.Now.AddYears(5));
+
+            // Save the certificate to a file or keep it in memory
+            // For in-memory usage in testing, you might not need to export it
+            return new X509Certificate2(certificate.Export(X509ContentType.Pfx, "yourPfxPassword"), "yourPfxPassword", X509KeyStorageFlags.DefaultKeySet);
+        }
+    }
+}

--- a/TokenGenerator/Services/SelfSignedCertificate.cs
+++ b/TokenGenerator/Services/SelfSignedCertificate.cs
@@ -8,45 +8,39 @@ namespace TokenGenerator.Services;
 
 public class SelfSignedCertificate : ICertificateService
 {
-    private readonly Lazy<Task<X509Certificate2>> _lazyCertificate;
+    private readonly Lazy<X509Certificate2> lazyCertificate;
 
     public SelfSignedCertificate()
     {
-        _lazyCertificate = new Lazy<Task<X509Certificate2>>(GenerateCertificate);
+        lazyCertificate = new Lazy<X509Certificate2>(GenerateCertificate);
     }
 
     public Task<X509Certificate2> GetApiTokenSigningCertificate(string environment)
     {
-        return _lazyCertificate.Value;
+        return Task.FromResult(lazyCertificate.Value);
     }
 
     public Task<X509Certificate2> GetConsentTokenSigningCertificate(string environment)
     {
-        return _lazyCertificate.Value;
+        return Task.FromResult(lazyCertificate.Value);
     }
 
     public Task<X509Certificate2> GetPlatformAccessTokenSigningCertificate(string environment)
     {
-        return _lazyCertificate.Value;
+        return Task.FromResult(lazyCertificate.Value);
     }
 
-    private async Task<X509Certificate2> GenerateCertificate()
+    private X509Certificate2 GenerateCertificate()
     {
-        using (RSA rsa = RSA.Create(2048))
-        {
-            var request = new CertificateRequest(
-                "cn=LocalTestCertificate",
-                rsa,
-                HashAlgorithmName.SHA256,
-                RSASignaturePadding.Pkcs1);
+        using RSA rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            "cn=LocalTestCertificate",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
 
-            var certificate = request.CreateSelfSigned(
-                DateTimeOffset.Now,
-                DateTimeOffset.Now.AddYears(5));
-
-            // Save the certificate to a file or keep it in memory
-            // For in-memory usage in testing, you might not need to export it
-            return new X509Certificate2(certificate.Export(X509ContentType.Pfx, "yourPfxPassword"), "yourPfxPassword", X509KeyStorageFlags.DefaultKeySet);
-        }
+        return request.CreateSelfSigned(
+            DateTimeOffset.Now,
+            DateTimeOffset.Now.AddYears(5));
     }
 }

--- a/TokenGenerator/Startup.cs
+++ b/TokenGenerator/Startup.cs
@@ -26,6 +26,7 @@ namespace TokenGenerator
             builder.Services.AddOptions();
 
             //builder.Services.AddSingleton<ICertificateService, CertificatePfx>();
+            builder.Services.AddSingleton<ICertificateService, SelfSignedCertificate>();
             builder.Services.AddSingleton<ICertificateService, CertificateKeyVault>();
             builder.Services.AddSingleton<IToken, Token>();
             builder.Services.AddScoped<IAuthorizationBearer, AuthorizationBearer>();

--- a/TokenGenerator/Startup.cs
+++ b/TokenGenerator/Startup.cs
@@ -27,7 +27,7 @@ namespace TokenGenerator
 
             //builder.Services.AddSingleton<ICertificateService, CertificatePfx>();
             builder.Services.AddSingleton<ICertificateService, SelfSignedCertificate>();
-            builder.Services.AddSingleton<ICertificateService, CertificateKeyVault>();
+            //builder.Services.AddSingleton<ICertificateService, CertificateKeyVault>();
             builder.Services.AddSingleton<IToken, Token>();
             builder.Services.AddScoped<IAuthorizationBearer, AuthorizationBearer>();
             builder.Services.AddScoped<IAuthorizationBasic, AuthorizationBasic>();

--- a/TokenGenerator/Startup.cs
+++ b/TokenGenerator/Startup.cs
@@ -25,9 +25,9 @@ namespace TokenGenerator
             builder.Services.Configure<Settings>(config.GetSection("Settings"));
             builder.Services.AddOptions();
 
+            //builder.Services.AddSingleton<ICertificateService, SelfSignedCertificate>();
             //builder.Services.AddSingleton<ICertificateService, CertificatePfx>();
-            builder.Services.AddSingleton<ICertificateService, SelfSignedCertificate>();
-            //builder.Services.AddSingleton<ICertificateService, CertificateKeyVault>();
+            builder.Services.AddSingleton<ICertificateService, CertificateKeyVault>();
             builder.Services.AddSingleton<IToken, Token>();
             builder.Services.AddScoped<IAuthorizationBearer, AuthorizationBearer>();
             builder.Services.AddScoped<IAuthorizationBasic, AuthorizationBasic>();

--- a/TokenGenerator/TokenGenerator.csproj
+++ b/TokenGenerator/TokenGenerator.csproj
@@ -5,15 +5,15 @@
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.10.4" />
+    <PackageReference Include="Azure.Identity" Version="1.11.3" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.6.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.5.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.5.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.5.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.5.1" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.3.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Certificates\apitoken.pfx">


### PR DESCRIPTION
## Description
This adds support for generating system users tokens as specified in https://docs.digdir.no/docs/Maskinporten/maskinporten_func_systembruker 

Current implementation does not add exchange specific claims, but aims to mimic Maskinporten claims (with the exception of `iss` and `actual_iss`) 

This also adds a simple `ICertificateService` implementation using a generated, self-signed cert for easier local testing. Dependencies are also updated.