### PR TITLE
Remove Maskinporten ver2 environment

### DIFF
--- a/TokenGenerator/Services/AuthorizationBearer.cs
+++ b/TokenGenerator/Services/AuthorizationBearer.cs
@@ -22,9 +22,7 @@ namespace TokenGenerator.Services
     {
         private readonly Settings settings;
         private readonly object cmLockMaskinporten = new object();
-        private readonly object cmLockMaskinportenAux = new object();
         private ConfigurationManager<OpenIdConnectConfiguration> configurationManager;
-        private ConfigurationManager<OpenIdConnectConfiguration> configurationManagerAux;
         private readonly HttpContext httpContext;
 
         private ConfigurationManager<OpenIdConnectConfiguration> ConfigurationManager
@@ -41,23 +39,6 @@ namespace TokenGenerator.Services
                 }
 
                 return configurationManager;
-            }
-        }
-
-        private ConfigurationManager<OpenIdConnectConfiguration> ConfigurationManagerAux
-        {
-            get
-            {
-                if (configurationManagerAux != null) return configurationManagerAux;
-                lock (cmLockMaskinportenAux)
-                {
-                    configurationManagerAux ??= new ConfigurationManager<OpenIdConnectConfiguration>(
-                        settings.TokenAuxiliaryAuthorizationWellKnownEndpoint,
-                        new OpenIdConnectConfigurationRetriever(),
-                        new HttpClient {Timeout = TimeSpan.FromMilliseconds(10000)});
-                }
-
-                return configurationManagerAux;
             }
         }
 
@@ -83,11 +64,6 @@ namespace TokenGenerator.Services
                 OpenIdConnectConfiguration configuration = await ConfigurationManager.GetConfigurationAsync();
                 var signingKeys = new List<SecurityKey>();
                 signingKeys.AddRange(configuration.SigningKeys);
-                if (settings.TokenAuxiliaryAuthorizationWellKnownEndpoint != null)
-                {
-                    OpenIdConnectConfiguration configurationAux = await ConfigurationManagerAux.GetConfigurationAsync();
-                    signingKeys.AddRange(configurationAux.SigningKeys);
-                }
 
                 TokenValidationParameters parameters = new TokenValidationParameters()
                 {

--- a/TokenGenerator/Settings.cs
+++ b/TokenGenerator/Settings.cs
@@ -21,8 +21,6 @@ namespace TokenGenerator
         public string AuthorizedScopePersonal { get; set; }
         public string AuthorizedScopePlatform { get; set; }
         public string TokenAuthorizationWellKnownEndpoint { get; set; }
-
-        public string TokenAuxiliaryAuthorizationWellKnownEndpoint { get; set; }
         public string EnvironmentsApiToken { get; set; }
         public string EnvironmentsConsentToken { get; set; }
         public Dictionary<string, string> EnvironmentsApiTokenDict => GetKeyValuePairs(EnvironmentsApiToken);

--- a/TokenGenerator/local.settings.json.COPYME
+++ b/TokenGenerator/local.settings.json.COPYME
@@ -17,7 +17,6 @@
     "ConsentTokenSigningCertNames": "dev:altinn-testtools-consent-token-signing-cert",
     "EnvironmentsApiToken": "dev:altinn-testtools-kv",
     "EnvironmentsConsentToken": "dev:altinn-testtools-kv",
-    "TokenAuthorizationWellKnownEndpoint": "https://test.maskinporten.no/.well-known/oauth-authorization-server",
-    "TokenAuxiliaryAuthorizationWellKnownEndpoint": "https://ver2.maskinporten.no/.well-known/oauth-authorization-server"
+    "TokenAuthorizationWellKnownEndpoint": "https://test.maskinporten.no/.well-known/oauth-authorization-server"
   }
 }


### PR DESCRIPTION
Maskinporten ver2 environment has been shut down. Removing settings and code trying to read the oidc config endpoint which is now shut off.