### PR TITLE
Added TTD org issuer support for PlatformAccessTokens

### DIFF
--- a/TokenGenerator/GetPlatformAccessToken.cs
+++ b/TokenGenerator/GetPlatformAccessToken.cs
@@ -34,6 +34,7 @@ namespace TokenGenerator
 
             requestValidator.ValidateQueryParam("env", true, tokenHelper.IsValidEnvironment, out string env);
             requestValidator.ValidateQueryParam("app", true, tokenHelper.IsValidDottedIdentifier, out string appClaim);
+            requestValidator.ValidateQueryParam("org", false, tokenHelper.IsValidIdentifier, out string issuerOrg);
             requestValidator.ValidateQueryParam<uint>("ttl", false, uint.TryParse, out uint ttl, 1800);
 
             if (requestValidator.GetErrors().Count > 0)
@@ -41,7 +42,7 @@ namespace TokenGenerator
                  return new BadRequestObjectResult(requestValidator.GetErrors());
             }
 
-            string token = await tokenHelper.GetPlatformAccessToken(env, appClaim, ttl);
+            string token = await tokenHelper.GetPlatformAccessToken(env, appClaim, ttl, issuerOrg ?? settings.PlatformAccessTokenIssuerName);
 
             if (!string.IsNullOrEmpty(req.Query["dump"]))
             {

--- a/TokenGenerator/Services/CertificateKeyVault.cs
+++ b/TokenGenerator/Services/CertificateKeyVault.cs
@@ -56,14 +56,31 @@ namespace TokenGenerator.Services
             return GetLatestCertificateWithRolloverDelay(certificates, 1);
         }
 
-        public async Task<X509Certificate2> GetPlatformAccessTokenSigningCertificate(string environment)
+        public async Task<X509Certificate2> GetPlatformAccessTokenSigningCertificate(string environment, string issuer)
         {
-            if (string.IsNullOrEmpty(environment) || settings.EnvironmentsApiTokenDict[environment] == null || settings.PlatformAccessTokenSigningCertNamesDict[environment] == null)
+            List<X509Certificate2> certificates = null;
+            if (issuer == settings.PlatformAccessTokenIssuerName)
             {
-                throw new ArgumentException("Invalid environment");
-            }
+                if (string.IsNullOrEmpty(environment) || settings.EnvironmentsApiTokenDict[environment] == null || settings.PlatformAccessTokenSigningCertNamesDict[environment] == null)
+                {
+                    throw new ArgumentException("Invalid environment");
+                }
 
-            var certificates = await GetCertificates(settings.EnvironmentsApiTokenDict[environment], settings.PlatformAccessTokenSigningCertNamesDict[environment]);
+                certificates = await GetCertificates(settings.EnvironmentsApiTokenDict[environment], settings.PlatformAccessTokenSigningCertNamesDict[environment]);
+            }
+            else if (issuer == settings.TtdAccessTokenIssuerName)
+            {
+                if (string.IsNullOrEmpty(issuer) || settings.EnvironmentsApiTokenDict[environment] == null || settings.TtdAccessTokenSigningCertNamesDict[environment] == null)
+                {
+                    throw new ArgumentException("Invalid environment or org issuer");
+                }
+
+                certificates = await GetCertificates(settings.EnvironmentsApiTokenDict[environment], settings.TtdAccessTokenSigningCertNamesDict[environment]);
+            }
+            else
+            {
+                throw new ArgumentException("Invalid issuer");
+            }
 
             return GetLatestCertificateWithRolloverDelay(certificates, 1);
         }

--- a/TokenGenerator/Services/CertificatePfx.cs
+++ b/TokenGenerator/Services/CertificatePfx.cs
@@ -57,5 +57,10 @@ namespace TokenGenerator.Services
         {
             throw new NotImplementedException();
         }
+
+        public Task<X509Certificate2> GetPlatformAccessTokenSigningCertificate(string environment, string issuer)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/TokenGenerator/Services/Interfaces/ICertificateService.cs
+++ b/TokenGenerator/Services/Interfaces/ICertificateService.cs
@@ -7,6 +7,6 @@ namespace TokenGenerator.Services.Interfaces
     {
         Task<X509Certificate2> GetApiTokenSigningCertificate(string environment);
         Task<X509Certificate2> GetConsentTokenSigningCertificate(string environment);
-        Task<X509Certificate2> GetPlatformAccessTokenSigningCertificate(string environment);
+        Task<X509Certificate2> GetPlatformAccessTokenSigningCertificate(string environment, string issuer);
     }
 }

--- a/TokenGenerator/Services/Interfaces/IToken.cs
+++ b/TokenGenerator/Services/Interfaces/IToken.cs
@@ -12,7 +12,7 @@ namespace TokenGenerator.Services.Interfaces
         Task<string> GetPersonalToken(string env, string[] scopes, uint userId, uint partyId, string pid, string authLvl, string consumerOrgNo, string userName, string clientAmr, uint ttl, string delegationSource);
         Task<string> GetConsentToken(string env, string[] serviceCodes, IQueryCollection queryParameters, Guid authorizationCode, string offeredBy, string coveredBy, string handledBy, uint ttl);
         Task<string> GetPlatformToken(string env, string appClaim, uint ttl);
-        Task<string> GetPlatformAccessToken(string env, string appClaim, uint ttl);
+        Task<string> GetPlatformAccessToken(string env, string appClaim, uint ttl, string iss = "platform");
 
         string Dump(string token);
         bool IsValidAuthLvl(string authLvl);

--- a/TokenGenerator/Services/SelfSignedCertificate.cs
+++ b/TokenGenerator/Services/SelfSignedCertificate.cs
@@ -25,7 +25,7 @@ public class SelfSignedCertificate : ICertificateService
         return Task.FromResult(lazyCertificate.Value);
     }
 
-    public Task<X509Certificate2> GetPlatformAccessTokenSigningCertificate(string environment)
+    public Task<X509Certificate2> GetPlatformAccessTokenSigningCertificate(string environment, string issuer)
     {
         return Task.FromResult(lazyCertificate.Value);
     }

--- a/TokenGenerator/Services/Token.cs
+++ b/TokenGenerator/Services/Token.cs
@@ -301,10 +301,23 @@ namespace TokenGenerator.Services
         /// <param name="env">The environment id.</param>
         /// <param name="appClaim">The name of the platform application.</param>
         /// <param name="ttl">Time to live.</param>
-        public async Task<string> GetPlatformAccessToken(string env, string appClaim, uint ttl)
+        /// <param name="issuer">The issuer of the token. Default is <c>platform</c>.</param>
+        public async Task<string> GetPlatformAccessToken(string env, string appClaim, uint ttl, string issuer)
         {
-            var signingCertificate = await certificateHelper.GetPlatformAccessTokenSigningCertificate(env);
-            return CreateAccessToken(appClaim, ttl, "platform", signingCertificate);
+            if (issuer == settings.PlatformAccessTokenIssuerName)
+            {
+                var signingCertificate = await certificateHelper.GetPlatformAccessTokenSigningCertificate(env, settings.PlatformAccessTokenIssuerName);
+                return CreateAccessToken(appClaim, ttl, settings.PlatformAccessTokenIssuerName, signingCertificate);
+            }
+            else if (issuer == settings.TtdAccessTokenIssuerName)
+            {
+                var signingCertificate = await certificateHelper.GetPlatformAccessTokenSigningCertificate(env, settings.TtdAccessTokenIssuerName);
+                return CreateAccessToken(appClaim, ttl, settings.TtdAccessTokenIssuerName, signingCertificate);
+            }
+            else
+            {
+                throw new ArgumentException("Invalid issuer");
+            }
         }
 
         public bool TryParseScopes(string input, out string[] scopes)

--- a/TokenGenerator/Settings.cs
+++ b/TokenGenerator/Settings.cs
@@ -8,8 +8,12 @@ namespace TokenGenerator
     {
         public string ApiTokenSigningCertNames { get; set; }
         public Dictionary<string, string> ApiTokenSigningCertNamesDict => GetKeyValuePairs(ApiTokenSigningCertNames);
+        public string PlatformAccessTokenIssuerName { get; set; }
         public string PlatformAccessTokenSigningCertNames { get; set; }
         public Dictionary<string, string> PlatformAccessTokenSigningCertNamesDict => GetKeyValuePairs(PlatformAccessTokenSigningCertNames);
+        public string TtdAccessTokenIssuerName { get; set; }
+        public string TtdAccessTokenSigningCertNames { get; set; }
+        public Dictionary<string, string> TtdAccessTokenSigningCertNamesDict => GetKeyValuePairs(TtdAccessTokenSigningCertNames);
         public string ConsentTokenSigningCertNames { get; set; }
         public Dictionary<string, string> ConsentTokenSigningCertNamesDict => GetKeyValuePairs(ConsentTokenSigningCertNames);
         public string BasicAuthorizationUsers { get; set; }

--- a/TokenGenerator/TokenGenerator.csproj
+++ b/TokenGenerator/TokenGenerator.csproj
@@ -5,15 +5,15 @@
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.11.3" />
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.6.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.5.1" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.5.1" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.3.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.1.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.1.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.4.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.1.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Certificates\apitoken.pfx">

--- a/TokenGenerator/local.settings.json.COPYME
+++ b/TokenGenerator/local.settings.json.COPYME
@@ -6,7 +6,10 @@
   },
   "Settings": {
     "ApiTokenSigningCertNames": "dev:altinn-testtools-api-token-signing-cert",
+    "PlatformAccessTokenIssuerName": "platform",
     "PlatformAccessTokenSigningCertNames": "dev:altinn-testtools-api-token-signing-cert",
+    "TtdAccessTokenIssuerName": "ttd",
+    "TtdAccessTokenSigningCertNames": "dev:altinn-testtools-ttd-accesstoken-signing-cert",
     "AuthorizedScope": "altinn:testtools/tokengenerator",
     "AuthorizedScopeEnterprise": "altinn:testtools/tokengenerator/enterprise",
     "AuthorizedScopeEnterpriseUser": "altinn:testtools/tokengenerator/enterpriseuser",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Test serviceowner Testdepartementet (ttd) has been added as a valid issuer of PlatformAccessTokens, in order to support both manual and automated testing of Altinn 3 Platform APIs provided to App-backend solutions running in a service owners own cluster.

These tokens are use the serviceowner's org code as issuer (iss claim) and are signed with a private certificate available for all apps in the cluster.

## Related Issue(s)
- [#827](https://github.com/Altinn/altinn-access-management/issues/827)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
