### PR TITLE
Added own config value for mapping KV used for getting cert for TTD access tokens

### DIFF
--- a/TokenGenerator/Services/CertificateKeyVault.cs
+++ b/TokenGenerator/Services/CertificateKeyVault.cs
@@ -70,12 +70,12 @@ namespace TokenGenerator.Services
             }
             else if (issuer == settings.TtdAccessTokenIssuerName)
             {
-                if (string.IsNullOrEmpty(issuer) || settings.EnvironmentsApiTokenDict[environment] == null || settings.TtdAccessTokenSigningCertNamesDict[environment] == null)
+                if (string.IsNullOrEmpty(issuer) || settings.EnvironmentsTtdAccessTokenDict[environment] == null || settings.TtdAccessTokenSigningCertNamesDict[environment] == null)
                 {
                     throw new ArgumentException("Invalid environment or org issuer");
                 }
 
-                certificates = await GetCertificates(settings.EnvironmentsApiTokenDict[environment], settings.TtdAccessTokenSigningCertNamesDict[environment]);
+                certificates = await GetCertificates(settings.EnvironmentsTtdAccessTokenDict[environment], settings.TtdAccessTokenSigningCertNamesDict[environment]);
             }
             else
             {

--- a/TokenGenerator/Settings.cs
+++ b/TokenGenerator/Settings.cs
@@ -27,8 +27,10 @@ namespace TokenGenerator
         public string TokenAuthorizationWellKnownEndpoint { get; set; }
         public string EnvironmentsApiToken { get; set; }
         public string EnvironmentsConsentToken { get; set; }
+        public string EnvironmentsTtdAccessToken { get; set; }
         public Dictionary<string, string> EnvironmentsApiTokenDict => GetKeyValuePairs(EnvironmentsApiToken);
         public Dictionary<string, string> EnvironmentsConsentTokenDict => GetKeyValuePairs(EnvironmentsConsentToken);
+        public Dictionary<string, string> EnvironmentsTtdAccessTokenDict => GetKeyValuePairs(EnvironmentsTtdAccessToken);
 
         private Dictionary<string, string> GetKeyValuePairs(string stringfieldToSpilt, char fieldSeparator = ';', char keyValueSeparator = ':')
         {

--- a/TokenGenerator/local.settings.json.COPYME
+++ b/TokenGenerator/local.settings.json.COPYME
@@ -20,6 +20,7 @@
     "ConsentTokenSigningCertNames": "dev:altinn-testtools-consent-token-signing-cert",
     "EnvironmentsApiToken": "dev:altinn-testtools-kv",
     "EnvironmentsConsentToken": "dev:altinn-testtools-kv",
+    "EnvironmentsTtdAccessToken": "dev:altinn-testtools-kv",
     "TokenAuthorizationWellKnownEndpoint": "https://test.maskinporten.no/.well-known/oauth-authorization-server"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added own config value for mapping KV used for getting cert for TTD access tokens

## Related Issue(s)
- [#827](https://github.com/Altinn/altinn-access-management/issues/827)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
