### PR TITLE
Set 'urn:altinn:authenticatemethod' to 'maskinporten' for systemuser tokens

### DIFF
--- a/TokenGenerator/Services/Token.cs
+++ b/TokenGenerator/Services/Token.cs
@@ -149,7 +149,7 @@ namespace TokenGenerator.Services
                 { "iat", dateTimeOffset.ToUnixTimeSeconds() },
                 { "jti", RandomString(43) },
                 { "authorization_details", GetAuthorizationDetailsForSystemUser(systemUserOrg, systemUserId) },
-                { "urn:altinn:authenticatemethod", "systemuser" },
+                { "urn:altinn:authenticatemethod", "maskinporten" },
                 { "urn:altinn:authlevel", 3 },
                 { "token_type", "Bearer" },
                 { "nbf", dateTimeOffset.ToUnixTimeSeconds() },


### PR DESCRIPTION
## Description
A systemuser token originates from Maskinporten and is optionally exchanged to an Altinn token.
`urn:altinn:authenticatemethod` is only present when exchanged, and is then set to `maskinporten`, not `systemuser`

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
