### PR TITLE
Allow authentication level 1 and 2

### DIFF
--- a/TokenGenerator/Services/Token.cs
+++ b/TokenGenerator/Services/Token.cs
@@ -375,7 +375,7 @@ namespace TokenGenerator.Services
 
         public bool IsValidAuthLvl(string authLvl)
         {
-            return authLvl == "3" || authLvl == "4";
+            return authLvl == "1" || authLvl == "2" || authLvl == "3" || authLvl == "4";
         }
 
         public bool IsValidEnvironment(string env)


### PR DESCRIPTION
## Description
The token generator is being called to generate tokens with level 1 and 2 at the moment. This will allow such use. Not sure if it's ideal though.

This was discovered based on a large amount of 401 errors in Storage (and in Altinn 2). There are tests that use password and Altinn Pin authentication.