### PR TITLE
Added support for hyphens (-) in the dotted identifier regex

### DIFF
--- a/TokenGenerator/Services/Token.cs
+++ b/TokenGenerator/Services/Token.cs
@@ -355,7 +355,7 @@ namespace TokenGenerator.Services
 
         public bool IsValidDottedIdentifier(string identifier)
         {
-            return !string.IsNullOrEmpty(identifier) && identifier.Length <= 50 && Regex.IsMatch(identifier, @"^(?:[a-z0-9_]\.?)+[a-z0-9_]$");
+            return !string.IsNullOrEmpty(identifier) && identifier.Length <= 50 && Regex.IsMatch(identifier, @"^(?:[a-z0-9_-]\.?)+[a-z0-9_-]$");
         }
 
         public bool IsValidOrgNo(string orgNo)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The [change to the dotted identifier check](https://github.com/Altinn/AltinnTestTools/commit/bb08f88b569116821d45a68198d01bfc6e1dffad) has broken a bunch of automated tests in accessmanagement as many apps use hyphens in app name.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

