### PR TITLE
bug: Downgrade Microsoft.Extension.Http to .net 6 supported v8.0.1

### DIFF
--- a/TokenGenerator/TokenGenerator.csproj
+++ b/TokenGenerator/TokenGenerator.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.1.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.1.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.4.1" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previous PR #49 introduced Microsoft.Extension.Http dependency but accidentally chose version without .net 6 support
